### PR TITLE
start printing out percentage of non-free packages

### DIFF
--- a/vrms_arch/license_finder.py
+++ b/vrms_arch/license_finder.py
@@ -181,6 +181,9 @@ FREE_LICENSES = [clean_license_name(license) for license in [
 
 class LicenseFinder(object):
     def __init__(self):
+        # number of packages
+        self.num_pkgs = set()
+
         # all of the seen (clean) license names with counts
         self.by_license = {}
 
@@ -195,6 +198,7 @@ class LicenseFinder(object):
 
     def visit_db(self, db):
         pkgs = db.packages
+        self.num_pkgs = len(db.packages)
 
         free_pkgs = []
 
@@ -254,6 +258,7 @@ class LicenseFinder(object):
         for nfpackage in sorted(self.nonfree_packages, key=lambda pkg: pkg.name):
             print("%s: %s" % (nfpackage.name, nfpackage.licenses))
 
-        print("\nNon-free packages: %d\n" % len(self.nonfree_packages), file=sys.stderr)
+        print("\nNon-free packages: %d (%.2f%% of total)\n" % (len(self.nonfree_packages),
+            ((len(self.nonfree_packages) / float(self.num_pkgs)) * 100)), file=sys.stderr)
 
         print("However, there are %d ambiguously licensed packages that vrms cannot certify." % len(self.unknown_packages), file=sys.stderr)


### PR DESCRIPTION
this would make the output look more like other versions of `vrms` such as the [original](https://github.com/suve/vrms-rpm/blob/96ce9d532fa7dbdb4a64b2caed7b723a66b57fee/lang/en.po#L15) and [vrms-rpm](https://github.com/suve/vrms-rpm/blob/96ce9d532fa7dbdb4a64b2caed7b723a66b57fee/lang/en.po#L15)